### PR TITLE
Set USE_SINGLE_BUILDDIR=1, so loki builds into deterministic directory

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -5,5 +5,5 @@ cd src/loki
 git submodule init
 git submodule update
 # attempt a build to set up some basics
-make
+USE_SINGLE_BUILDDIR=1 make
 cd ../..


### PR DESCRIPTION
Upstream there's a change where loki builds into a named subdirectory based on your platform and git tree, i.e. `build/Linux/dev/debug/bin` instead of just `build/debug/bin/`

Passing USE_SINGLE_BUILDDIR to make will make it build back into the 2nd option.