### PR TITLE
Minor documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ This will use npm to install the launcher
 
 `sudo npm install -g loki-launcher`
 
+This will download and install the Loki binaries for you if you don't already have them
+
+`sudo loki-launcher download-binaries`
+
 This will create any needed directories and make sure everything has the proper permissions to run as a specified user such as `snode` in this example
 
 `sudo loki-launcher set-perms snode`
@@ -55,10 +59,6 @@ Now make sure sure you running the following commands as the user specified or y
 After it's installed, you can ask to prequalify your server to be a service node
 
 `loki-launcher prequal`
-
-you can also ask it to download the Loki binaries if you don't already have them
-
-`loki-launcher download-binaries`
 
 # How to use without systemd
 
@@ -91,7 +91,7 @@ And be sure to make sure you restart your service node (if it's staked) by
 
 ## Get the latest Loki software versions
 
-`loki-launcher download-binaries`
+`sudo loki-launcher download-binaries`
 
 And be sure to make sure you restart your service node (if it's staked) by
 


### PR DESCRIPTION
To the right repo this time.
`loki-launcher download-binaries` needs sudo/root.
`set-perms` complains when run before the binaries have been downloaded to their expected locations.
Also a change in wording to make it sound less optional, as most users would probably want to run this.