### PR TITLE
v1.0.24

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -1093,7 +1093,9 @@ function arrayHasClOption(arr, option) {
 function configureLokid(config, args) {
   //console.log('configureLokid', args)
   var lokid_options = []
-  if (!arrayHasClOption(args, '--service-node')) {
+  // this matches --service-node-...
+  if (!arrayHasClOption(args, /^--service-node$/)) {
+    //console.log('adding --SN')
     lokid_options.push('--service-node')
   }
 
@@ -1174,7 +1176,9 @@ function configureLokid(config, args) {
       lokid_options.push('--storage-server-port', config.storage.port)
     }
     // make sure not passed in xmrOptions
+    //console.log('args', args)
     if (!arrayHasClOption(args, '--service-node-public-ip')) {
+      //console.log('adding', config.launcher.publicIPv4)
       lokid_options.push('--service-node-public-ip', config.launcher.publicIPv4)
     }
   } else {
@@ -1186,12 +1190,139 @@ function configureLokid(config, args) {
   }
 
   // copy CLI options to lokid
+  var normalizeArgs = []
+  function normalizeSet(key, value) {
+    //console.log('set?', key, ':', value)
+    // remove any previous setting
+    normalizeArgs = normalizeArgs.filter(item => {
+      var parts = item.replace(/^--/, '').split(/=/)
+      var newSet = key !== parts.shift()
+      if (!newSet) {
+        console.warn('Overriding earlier option of', item)
+      }
+      return newSet
+    })
+    // always add the new setting
+    normalizeArgs.push('--' + key + '=' + value)
+  }
+
+  // what if we normalize them into an array
+  var last = null
+  var all_options = lokid_options.concat(args)
+  //console.log('all_options', all_options)
+  for (var i in all_options) {
+    // should we prevent --non-interactive?
+    // probably not, if they want to run it that way, why not support it?
+
+    // FIXME: we just need to adjust internal config
+    // do we?
+    var arg = '' + all_options[i]
+    //console.log('arg', arg)
+
+    if (arg.match(/^--/)) {
+      // -- part
+      if (last != null) {
+        // if last was --!=
+        // now removeDashes is definitely not a value
+        // codify no value...
+        normalizeSet(last, '__REMOVE_ME__', false)
+        last = null
+      }
+      var removeDashes = arg.replace(/^--/, '')
+      if (arg.match(/=/)) {
+        var parts = removeDashes.split(/=/)
+        var key = parts.shift()
+        var value = parts.join('=')
+        normalizeSet(key, value, false)
+        last = null
+      } else {
+        // read next to make a decision
+        last = removeDashes
+      }
+    } else {
+      // hack to allow equal to be optional..
+      if (last != null) {
+        // should stitch together last = arg
+        normalizeSet(last, arg, true)
+      }
+      last = null
+    }
+  }
+  //console.log('last', last)
+  // and process them as such...
+  //console.log('normalized args', normalizeArgs)
+  lokid_options = normalizeArgs.map(str => str.replace('=__REMOVE_ME__', ''))
+  // well we used 2 buckets before
+  // so we didn't collide on current item
+  // if we use lokid_options then we're back to the parse problem...
+
+  /*
+  function removeSetOptions(key, value, spaceSepOption) {
+    console.log('removeSetOptions', key, value, spaceSepOption)
+    for(var j in lokid_options) {
+      var option = lokid_options[j] + '' // have to convert to string because number become numbers
+      // FIXME what about ' ' options?
+      console.log('checking', option, '==', key)
+      if ((option.match && option.match(/=/)) || ((value === true || spaceSepOption === true) && key === option)) {
+        var parts2 = option.split(/=/)
+        var option_key = parts2.shift()
+        console.log('checking key', option_key)
+        if (spaceSepOption) {
+          // skip if the j === lokid_options.length -1
+          console.log(j, '===', lokid_options.length - 1, lokid_options.length - 1 === +j)
+          if (lokid_options.length - 1 === +j) {
+            continue
+            // but isn't this always the case...
+          }
+        }
+        if (option_key == key) {
+          // warn if stomping an INI settings, set above...
+          // but we promote xmr options to INI/config...
+          // but we'll skip it now with arrayHasClOption
+          console.log('BLOCKCHAIN: Removing previous established option', option)
+          lokid_options.splice(j, 1)
+        }
+      }
+    }
+  }
+  var last = null
   for (var i in args) {
     // should we prevent --non-interactive?
     // probably not, if they want to run it that way, why not support it?
+
     // FIXME: we just need to adjust internal config
     var arg = args[i]
-    //console.log('arg', arg)
+    console.log('arg', arg)
+
+    if (arg.match(/^--/)) {
+      var removeDashes = arg.replace(/^--/, '')
+      if (arg.match(/=/)) {
+        var parts = removeDashes.split(/=/)
+        var key = parts.shift()
+        var value = parts.join('=')
+        removeSetOptions('--' + key, value, false)
+        last = null
+      } else {
+        // -- part
+        if (last != null) {
+          // if last was --!=
+          // now removeDashes is definitely not a value
+          removeSetOptions('--' + last, true, false)
+          last = null
+        }
+        // read next to make a decision
+        last = '--' + removeDashes
+      }
+    } else {
+      // hack to allow equal to be optional..
+      if (last != null) {
+        // should stitch together last = arg
+        removeSetOptions(last, arg, true)
+      }
+      last = null
+    }
+    */
+    /*
     if (arg.match(/=/)) {
       // assignment
       var parts = arg.split(/=/)
@@ -1212,6 +1343,9 @@ function configureLokid(config, args) {
         }
       }
     } else {
+      // arg doesn't contain =
+      // does it contain --
+      // does the next arg contain --
       for(var j in lokid_options) {
         var option = lokid_options[j]
         if (arg == option) {
@@ -1220,9 +1354,12 @@ function configureLokid(config, args) {
         }
       }
     }
+    */
+  /*
     lokid_options.push(args[i])
-    //console.log('options', lokid_options)
+    console.log('options', lokid_options)
   }
+  */
   //console.log('final options', lokid_options)
 
   return {

--- a/daemon.js
+++ b/daemon.js
@@ -1272,7 +1272,8 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
       // 2020-10-12 03:11:00.660 I Failed to submit uptime proof: have not heard from the storage server recently. Make sure that it is running! It is required to run alongside the Loki daemon
 
       // we can get 3-4 before loki-storage pings a fresh restart
-      if (data.match(/Failed to submit uptime proof: have not heard from the storage server recently/)) {
+      var str = data.toString()
+      if (str.match(/Failed to submit uptime proof: have not heard from the storage server recently/)) {
         var ts = Date.now()
         lastLokiStorageContactFailures.push(ts)
         // loki-storage may not be running

--- a/lib.js
+++ b/lib.js
@@ -101,8 +101,10 @@ Cant detect blockchain version Error: Command failed: /opt/loki-launcher/bin/lok
       if (e.signal === 'SIGILL') {
         console.error("Cannot detect blockchain version. Your current lokid binary does not support your CPU")
       } else {
+        // not a crash but bad exit..
         if (e.signal === null && e.status === 1 && e.error === null) {
           // LIBC error
+          console.log('message', e.message)
         }
         console.error("Cannot detect blockchain version", e)
         //console.error('Cant detect blockchain version', e.stdout.toString())

--- a/lib.js
+++ b/lib.js
@@ -101,6 +101,9 @@ Cant detect blockchain version Error: Command failed: /opt/loki-launcher/bin/lok
       if (e.signal === 'SIGILL') {
         console.error("Cannot detect blockchain version. Your current lokid binary does not support your CPU")
       } else {
+        if (e.signal === null && e.status === 1 && e.error === null) {
+          // LIBC error
+        }
         console.error("Cannot detect blockchain version", e)
         //console.error('Cant detect blockchain version', e.stdout.toString())
       }
@@ -591,7 +594,22 @@ async function runStorageRPCTest(lokinet, config, cb) {
   }, 5000)
   var oldTLSValue = process.env["NODE_TLS_REJECT_UNAUTHORIZED"]
   process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = '0' // turn it off for now
-  const data =  await lokinet.httpGet(url)
+  let data
+  try {
+    data =  await lokinet.httpGet(url)
+  } catch(e) {
+    if (e !== undefined) {
+      if (e.code === 'ECONNREFUSED') {
+        // simply not listening/running (yet...?)
+      } else {
+        // most e are already displayed in httpGet
+        //console.error('runStorageRPCTest httpGet failure', e)
+      }
+    } else {
+      // a reject...
+      // shutdown or 404/403
+    }
+  }
   process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = oldTLSValue
   clearTimeout(storage_rpc_timer)
   if (responded) return

--- a/lokinet.js
+++ b/lokinet.js
@@ -190,7 +190,7 @@ function httpGet(url, cb) {
       clearInterval(stopWatchdog)
       //console.log('err', err)
       if (cb) cb()
-        else reject()
+        else reject(err)
     })
   })
   p.ref = ref

--- a/modes/fix-perms.js
+++ b/modes/fix-perms.js
@@ -141,7 +141,7 @@ function start(user, dir, config) {
           fs.chownSync(config.launcher.var_path, uid, 0)
           // should also make /opt/loki-launcher not root
           // but not /var
-          if (config.launcher.var_path == '/opt/loki-launcher/var') {
+          if (config.launcher.var_path === '/opt/loki-launcher/var') {
             fs.chownSync('/opt/loki-launcher', uid, 0)
           }
         }


### PR DESCRIPTION
- fix client mode
- don't allow doubling command line parameters to lokid
- fix passing additional command line args to lokid
- service-node-public-ip command line argument now can drives blockchain.p2p_ip (if publicIPv4 is overrode, that means the default gateway isn't going to work)