### PR TITLE
v1.0.29

### DIFF
--- a/daemon.js
+++ b/daemon.js
@@ -1437,7 +1437,7 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
       if (str.match(/Sync data returned a new top block candidate/)) {
         // these are normal, however too many in a row could mean a stall
         // especially combined with difficulty recalc
-        console.warn('no blockchain communication with other nodes, something maybe wrong...')
+        console.warn('no blockchain communication with other nodes, something maybe wrong or it\'s about to start a sync...')
       }
 
       // we can get 3-4 before loki-storage pings a fresh restart

--- a/daemon.js
+++ b/daemon.js
@@ -1368,6 +1368,8 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
   loki_daemon.storageFailures = {
 
   }
+  loki_daemon.status = {
+  }
   savePidConfig = {
     config: config,
     args: args,
@@ -1392,30 +1394,42 @@ function launchLokid(binary_path, lokid_options, interactive, config, args, cb) 
       if (str.match(/subsystems, scanning blockchain from height/)) {
         console.log('blockchain subsystem loading')
         loadingSubsystems = true
+        loki_daemon.status.loadingSubsystems = true
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
       if (str.match(/... scanning height/)) {
         console.log('blockchain progress update')
         loadingSubsystems = true
+        loki_daemon.status.loadingSubsystems = true
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
       // 2020-09-28 01:47:50.074	I ... scanning height 121250 (4.9152s) (snl: 1.01874s; lns: 0s)
       // 2020-09-28 01:56:39.036	I Loading checkpoints
       if (str.match(/Loading checkpoints/)) {
         console.log('blockchain subsystem loaded')
         loadingSubsystems = false
+        loki_daemon.status.loadingSubsystems = false
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
 
       // syncingChain
       if (str.match(/SYNCHRONIZATION started/)) {
         console.log('blockchain sync started')
         syncingChain = true
+        loki_daemon.status.syncingChain = true
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
       if (str.match(/Synced/)) {
         // progress update
         syncingChain = true
+        loki_daemon.status.syncingChain = true
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
       if (str.match(/SYNCHRONIZED OK/)) {
         console.log('blockchain synchronized')
         syncingChain = false
+        loki_daemon.status.syncingChain = false
+        lib.savePids(config, args, loki_daemon, lokinet, storageServer)
       }
 
 

--- a/daemon.js
+++ b/daemon.js
@@ -868,20 +868,21 @@ function startLauncherDaemon(config, interactive, entryPoint, args, debug, cb) {
             // blockchain rpc is now required for SN
 
             var blockchainIsFine = pids.runningConfig && pids.runningConfig.blockchain && checklist.blockchain_rpc !== 'waiting...'
-            var networkIsFine = (!pids.runningConfig) || (!pids.runningConfig.network) || (!pids.runningConfig.network.enabled) || (checklist.network !== 'waiting...')
-            if (running.launcher && running.lokid && checklist.socketWorks !== 'waiting...' &&
-                  pids.runningConfig && blockchainIsFine && networkIsFine &&
-                  checklist.storageServer !== 'waiting...' && checklist.storage_rpc !== 'waiting...'
-                ) {
-              console.log('Start up successful!')
-              if (child) child.removeListener('close', crashHandler)
-              process.exit()
-            }
+            // donish conditions
             if (running.launcher && running.lokid && checklist.socketWorks !== 'waiting...' &&
                   pids.runningConfig && blockchainIsFine
                 ) {
-              if (checklist.blockchain_status.split(/ /).includes('syncingChain')) {
+              if (checklist.blockchain_status && checklist.blockchain_status.split(/ /).includes('syncingChain')) {
                 console.log('Blockchain is syncing, likely will be a long time until storage/network will be ready, check status periodically')
+                if (child) child.removeListener('close', crashHandler)
+                process.exit()
+              }
+              var networkIsFine = (!pids.runningConfig) || (!pids.runningConfig.network) || (!pids.runningConfig.network.enabled) || (checklist.network !== 'waiting...')
+              if (running.launcher && running.lokid && checklist.socketWorks !== 'waiting...' &&
+                    pids.runningConfig && blockchainIsFine && networkIsFine &&
+                    checklist.storageServer !== 'waiting...' && checklist.storage_rpc !== 'waiting...'
+                  ) {
+                console.log('Start up successful!')
                 if (child) child.removeListener('close', crashHandler)
                 process.exit()
               }

--- a/daemon.js
+++ b/daemon.js
@@ -1252,6 +1252,7 @@ function configureLokid(config, args) {
     //console.log('set?', key, ':', value)
     // remove any previous setting
     normalizeArgs = normalizeArgs.filter(item => {
+      // get key name
       var parts = item.replace(/^--/, '').split(/=/)
       var newSet = key !== parts.shift()
       if (!newSet) {
@@ -1282,7 +1283,7 @@ function configureLokid(config, args) {
         // if last was --!=
         // now removeDashes is definitely not a value
         // codify no value...
-        normalizeSet(last, '__REMOVE_ME__', false)
+        normalizeSet(last, '__REMOVE_ME__')
         last = null
       }
       var removeDashes = arg.replace(/^--/, '')
@@ -1290,7 +1291,7 @@ function configureLokid(config, args) {
         var parts = removeDashes.split(/=/)
         var key = parts.shift()
         var value = parts.join('=')
-        normalizeSet(key, value, false)
+        normalizeSet(key, value)
         last = null
       } else {
         // read next to make a decision
@@ -1298,14 +1299,18 @@ function configureLokid(config, args) {
       }
     } else {
       // hack to allow equal to be optional..
-      if (last != null) {
+      if (last !== null) {
         // should stitch together last = arg
-        normalizeSet(last, arg, true)
+        normalizeSet(last, arg)
       }
       last = null
     }
   }
   //console.log('last', last)
+  // flush the last if it's --testnet
+  if (last !== null) {
+    normalizeSet(last, '__REMOVE_ME__')
+  }
   // and process them as such...
   //console.log('normalized args', normalizeArgs)
   lokid_options = normalizeArgs.map(str => str.replace('=__REMOVE_ME__', ''))

--- a/daemon.js
+++ b/daemon.js
@@ -877,6 +877,15 @@ function startLauncherDaemon(config, interactive, entryPoint, args, debug, cb) {
               if (child) child.removeListener('close', crashHandler)
               process.exit()
             }
+            if (running.launcher && running.lokid && checklist.socketWorks !== 'waiting...' &&
+                  pids.runningConfig && blockchainIsFine
+                ) {
+              if (checklist.blockchain_status.split(/ /).includes('syncingChain')) {
+                console.log('Blockchain is syncing, likely will be a long time until storage/network will be ready, check status periodically')
+                if (child) child.removeListener('close', crashHandler)
+                process.exit()
+              }
+            }
             // if storage is enabled but not running, wait for it
             if (pids.runningConfig && pids.runningConfig.storage.enabled && checklist.storageServer === 'waiting...' && blockchainIsFine && networkIsFine) {
               // give it 30s more if everything else is fine... for what?

--- a/index.js
+++ b/index.js
@@ -153,16 +153,12 @@ async function continueStart() {
       var logo = lib.getLogo('git rev version')
       console.log(logo.replace(/version/, VERSION.toString()))
     } else {
-      var logo = lib.getLogo('L A U N C H E R   v e r s i o n   v version')
+      var logo = lib.getLogo('O X E N - R A N C H E R   v e r s i o n   v version')
       console.log(logo.replace(/version/, VERSION.toString().split('').join(' ')))
     }
   }
   if (showVersionCommands.includes(mode)) {
-    if (useGitVersion) {
-      console.log('Oxen-Rancher version', VERSION.toString())
-    } else {
-      console.log('Oxen-Rancher version', VERSION.toString())
-    }
+    console.log('Oxen-Rancher version', VERSION.toString())
   }
 
   var debugMode = mode.match(/debug/i)

--- a/lib.js
+++ b/lib.js
@@ -872,19 +872,19 @@ function stopLokid(config) {
 function stopLauncher(config) {
   const systemdUtils = require(__dirname + '/modes/check-systemd')
   if (systemdUtils.isSystemdEnabled(config)) {
-    console.log('systemd lokid service is enabled')
+    //console.log('systemd lokid service is enabled')
     if (systemdUtils.isStartedWithSystemD()) {
-      console.log('systemd lokid service is active, stopping with systemd')
+      //console.log('systemd lokid service is active, stopping with systemd')
       // are we root?
       if (process.getuid() !== 0) {
-        console.log("this command isn't running as root, so can't stop launcher, run again with sudo")
+        //console.log("this command isn't running as root, so can't stop launcher, run again with sudo")
       } else {
         try {
           const stdoutBuf = execSync('systemctl stop lokid')
           console.log("launcher has been stopped")
           return
         } catch(e) {
-          console.log("stopping failed, falling back")
+          console.log("stopping via systemd failed, falling back")
         }
       }
     }
@@ -899,8 +899,9 @@ function stopLauncher(config) {
   if (pid) {
     // request launcher stop
     if (systemdUtils.isStartedWithSystemD()) {
-      console.warn('launcher was set up with systemd, and you will need to')
-      console.warn('"sudo systemctl stop lokid.service" before running this')
+      console.warn('launcher was set up with systemd, and you will need to run with sudo like')
+      //console.warn('"sudo systemctl stop lokid.service" before running this')
+      console.warn('"sudo oxen-rancher stop"')
       // or should we just return 0?
       process.exit(1)
     }
@@ -911,6 +912,7 @@ function stopLauncher(config) {
     // we quit too fast
     //require(__dirname + '/client')(config)
   } else {
+    // if no launcher...look for orphans
     var running = getProcessState(config)
     var pids = getPids(config)
     count += stopLokid(config)

--- a/lib.js
+++ b/lib.js
@@ -23,21 +23,27 @@ function hereDoc(f) {
 }
 
 const logo = hereDoc(function () {/*!
-        .o0l.
-       ;kNMNo.
-     ;kNMMXd'
-   ;kNMMXd'                 .ld:             ,ldxkkkdl,.     'dd;     ,odl.  ;dd
- ;kNMMXo.  'ol.             ,KMx.          :ONXkollokXN0c.   cNMo   .dNNx'   dMW
-dNMMM0,   ;KMMXo.           ,KMx.        .oNNx'      .dNWx.  :NMo .cKWk;     dMW
-'dXMMNk;  .;ONMMXo'         ,KMx.        :NMx.         oWWl  cNWd;ON0:.      oMW
-  'dXMMNk;.  ;kNMMXd'       ,KMx.        lWWl          :NMd  cNMNNMWd.       dMW
-    'dXMMNk;.  ;kNMMXd'     ,KMx.        :NMx.         oWWl  cNMKolKWO,      dMW
-      .oXMMK;   ,0MMMNd.    ,KMx.        .dNNx'      .dNWx.  cNMo  .dNNd.    dMW
-        .lo'  'dXMMNk;.     ,KMXxdddddl.   :ONNkollokXN0c.   cNMo    ;OWKl.  dMW
-            'dXMMNk;        .lddddddddo.     ,ldxkkkdl,.     'od,     .cdo;  ;dd
-          'dXMMNk;
-         .oNMNk;             __LABEL__
-          .l0l.
+__LABEL__
+
+                                       /;    ;\
+                                   __  \\____//
+                                  /{_\_/   `'\____
+                                  \___   (o)  (o  }
+       _____________________________/          :--'
+   ,-,'`@@@@@@@@       @@@@@@         \_    `__\
+  ;:(  @@@@@@@@@        @@@             \___(o'o)
+  :: )  @@@@          @@@@@@        ,'@@(  `===='
+  :: : @@@@@:          @@@@         `@@@:
+  :: \  @@@@@:       @@@@@@@)    (  '@@@'
+  ;; /\      /`,    @@@@@@@@@\   :@@@@@)
+  ::/  )    {_----------------:  :~`,~~;
+ ;;'`; :   )                  :  / `; ;
+;;;; : :   ;                  :  ;  ; :
+`'`' / :  :                   :  :  : :
+    )_ \__;      ";"          :_ ;  \_\       `,','
+    :__\  \    * `,'*         \  \  :  \   *  8`;'*  *
+        `^'     \ :/           `^'  `-^-'   \v/ :  \/
+Art by Bill Ames
 */});
 
 function getLogo(str) {
@@ -382,7 +388,7 @@ function areWeRunning(config) {
     } else {
       // so many calls
       // do we need to say this everytime?
-      console.log('stale ' + config.launcher.var_path + '/launcher.pid, removing...')
+      console.log('stale ' + config.launcher.var_path + '/launcher.pid (' + pid + '), removing...')
       // should we nuke this proven incorrect file? yes
       fs.unlinkSync(config.launcher.var_path + '/launcher.pid')
       // FIXME: maybe have a lastrun file for debugging
@@ -419,6 +425,7 @@ function savePids(config, args, loki_daemon, lokinet, storageServer) {
     obj.blockchain_startedOptions = loki_daemon.startedOptions
     obj.blockchain_spawn_file     = loki_daemon.spawnfile
     obj.blockchain_spawn_args     = loki_daemon.spawnargs
+    obj.blockchain_status         = loki_daemon.status
   }
   if (storageServer && !storageServer.killed && storageServer.pid) {
     obj.storageServer      = storageServer.pid
@@ -745,6 +752,20 @@ async function getLauncherStatus(config, lokinet, offlineMessage, cb) {
       checklist.blockchain_rpc = offlineMessage
       checkDone('blockchain_rpc')
     }, 5000)
+
+    if (pids.blockchain_status) {
+      var status = []
+      if (pids.blockchain_status.loadingSubsystems) {
+        status.push('loadingSubsystems')
+      }
+      if (pids.blockchain_status.syncingChain) {
+        status.push('syncingChain')
+      }
+      if (status.length) {
+        checklist.blockchain_status = status.join(' ')
+      }
+    }
+
     // returns a promise now..
     try {
       var p = httpPost(url, '{}', function(data) {

--- a/lib.js
+++ b/lib.js
@@ -388,6 +388,7 @@ function areWeRunning(config) {
     } else {
       // so many calls
       // do we need to say this everytime?
+      // will be stale if launcher.cimode is true
       console.log('stale ' + config.launcher.var_path + '/launcher.pid (' + pid + '), removing...')
       // should we nuke this proven incorrect file? yes
       fs.unlinkSync(config.launcher.var_path + '/launcher.pid')

--- a/lib.js
+++ b/lib.js
@@ -103,7 +103,7 @@ Cant detect blockchain version Error: Command failed: /opt/loki-launcher/bin/lok
       */
       // stderr seems to be already echo'd
       if (e.code === 'EACCES') {
-        console.error("Cannot detect blockchain version. Your current oxend binary does not have the correct permissions, please run: 'sudo loki-launcher fix-perms USER' where USER is the username you run launcher as, usually snode")
+        console.error("Cannot detect blockchain version. Your current oxend binary does not have the correct permissions, please run: 'sudo oxen-rancher fix-perms USER' where USER is the username you run rancher as, usually snode")
       } else
       if (e.signal === 'SIGILL') {
         console.error("Cannot detect blockchain version. Your current oxend binary does not support your CPU")
@@ -181,7 +181,7 @@ function getStorageVersion(config) {
       */
     } catch(e) {
       if (e.code === 'EACCES') {
-        console.error("Cannot detect storage version. Your current oxen-storage binary does not have the correct permissions, please run: 'sudo loki-launcher fix-perms USER' where USER is the username you run launcher as, usually snode")
+        console.error("Cannot detect storage version. Your current oxen-storage binary does not have the correct permissions, please run: 'sudo oxen-rancher fix-perms USER' where USER is the username you run rancher as, usually snode")
       } else
       if (e.signal === 'SIGILL') {
         console.error("Cannot detect storage version. Your current oxen-storage binary does not support your CPU")
@@ -206,7 +206,7 @@ function getNetworkVersion(config) {
       return networkVersion
     } catch(e) {
       if (e.code === 'EACCES') {
-        console.error("Cannot detect network version. Your current lokinet binary does not have the correct permissions, please run: 'sudo loki-launcher fix-perms USER' where USER is the username you run launcher as, usually snode")
+        console.error("Cannot detect network version. Your current lokinet binary does not have the correct permissions, please run: 'sudo oxen-rancher fix-perms USER' where USER is the username you run rancher as, usually snode")
       } else
       if (e.signal === 'SIGILL') {
         console.error("Cannot detect network version. Your current lokinet binary does not support your CPU")
@@ -364,7 +364,7 @@ function areWeRunning(config) {
       }
       // detect incorrectly parsed ps
       if (!foundPid) {
-        console.warn('Could not read your process-list to determine if pid', pid, 'is really launcher or not', stdout)
+        console.warn('Could not read your process-list to determine if pid', pid, 'is really rancher or not', stdout)
       } else
       if (!verifiedPid) {
         // what's worse?
@@ -374,7 +374,7 @@ function areWeRunning(config) {
         // check the socket...
         // well clear the pid file
         // is it just the launcher running?
-        console.warn('Could not verify that pid', pid, 'is actually the launcher by process title')
+        console.warn('Could not verify that pid', pid, 'is actually the rancher by process title')
         const pids = getPids(config)
         const blockchainIsRunning = pids.lokid && isPidRunning(pids.lokid)
         const networkIsRunning = config.network.enabled && pids.lokinet && isPidRunning(pids.lokinet)

--- a/lokinet.js
+++ b/lokinet.js
@@ -1429,7 +1429,7 @@ function startServiceNode(config, cb) {
   checkConfig(networkConfig)
   var version = lib.getNetworkVersion(config)
   if (version.match('lokinet-0.8.') || version.match('lokinet-0.9.')) {
-    console.log('Detected Lokinet-8.x')
+    console.log('Detected Lokinet-8.x+')
     networkConfig.ini_writer = generateSerivceNodeINI8
     networkConfig.requireModeParam = true
   } else {

--- a/lokinet.js
+++ b/lokinet.js
@@ -136,7 +136,7 @@ function httpGet(url, cb) {
       path: urlDetails.path,
       timeout: 5000,
       headers: {
-        'User-Agent': 'Mozilla/5.0 Loki-launcher/' + VERSION
+        'User-Agent': 'Mozilla/5.0 Oxen-rancher/' + VERSION
       }
     }, (resp) => {
       //log('httpGet setting up handlers')
@@ -1356,7 +1356,7 @@ function checkConfig(config) {
         if (process.getgid() != 0) {
           console.error('')
           console.error(config.binary_path, 'does not have the correct setcap permissions: ', stdout)
-          console.error('Please run: "sudo loki-launcher fix-perms', os.userInfo().username, '" one time, so we can fix permissions on this binary!')
+          console.error('Please run: "sudo oxen-rancher fix-perms', os.userInfo().username, '" one time, so we can fix permissions on this binary!')
           console.error('shutting down...')
           console.error('')
           process.exit(1)

--- a/modes/check-systemd.js
+++ b/modes/check-systemd.js
@@ -179,16 +179,27 @@ function install(config, entrypoint, user) {
   //}
   console.log('loading systemd service file')
   systemd.refreshServices()
+  enable(config)
+}
+
+function enable(config) {
   console.log('enabling systemd service file on reboot')
-  systemd.serviceEnable('lokid')
+  return systemd.serviceEnable('lokid')
+}
+
+function disable(config) {
+  if (isEnabled(config)) {
+    console.log('service file is enabled, disabling it')
+    return systemd.serviceDisable('lokid')
+  }
+  return true
 }
 
 function uninstall(config) {
   if (isEnabled(config)) {
-    console.log('service file is enabled, disabling it')
     systemd.serviceStop('lokid')
-    systemd.serviceDisable('lokid')
   }
+  disable(config)
   if (fs.existsSync('/etc/systemd/system/lokid.service')) {
     console.log('service file exists, deleting it')
     fs.unlinkSync('/etc/systemd/system/lokid.service')
@@ -243,6 +254,8 @@ module.exports = {
   start: start, // upgrade/migrate older lokid
   install: install,
   uninstall: uninstall,
+  enable: enable,
+  disable: disable,
   hasDebsEnabled: hasDebsEnabled,
   launcherLogs: launcherLogs,
   isStartedWithSystemD: isActive,

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -264,16 +264,20 @@ async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       }
     }
 
-    if (os.platform() == 'linux') {
-      if (options.filename === 'lokinet' && options.notPrerelease) {
-        // get version number
-        //console.log('data', data)
-        const dirName = 'lokinet-linux-amd64-' + data.tag_name
-        options.ext = '.tar.xz'
-        const specialLokinetLinuxStaticBinaryUrl = 'https://oxen.rocks/oxen-io/loki-network/' + dirName + options.ext
-        downloadArchive(specialLokinetLinuxStaticBinaryUrl, config, options)
-        return
-      }
+    if (os.platform() !== 'linux') {
+      console.error('Sorry, platform', os.platform(), 'is not currently supported, please let us know you would like us to support this platform by opening an issue on github: https://github.com/hesiod-project/oxen-rancher/issues')
+      process.exit(1)
+    }
+    options.cb = cb
+
+    if (options.filename === 'lokinet' && options.notPrerelease) {
+      // get version number
+      //console.log('data', data)
+      const dirName = 'lokinet-linux-amd64-' + data.tag_name
+      options.ext = '.tar.xz'
+      const specialLokinetLinuxStaticBinaryUrl = 'https://oxen.rocks/oxen-io/loki-network/' + dirName + options.ext
+      downloadArchive(specialLokinetLinuxStaticBinaryUrl, config, options)
+      return
     }
     /*
     else {
@@ -282,19 +286,12 @@ async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
     }
     */
 
-    var search = 'UNKNOWN'
-    //if (os.platform() == 'darwin') search = 'osx'
-    //else
-    if (os.platform() == 'linux') search = 'linux'
-    else {
-      console.error('Sorry, platform', os.platform(), 'is not currently supported, please let us know you would like us to support this platform by opening an issue on github: https://github.com/hesiod-project/oxen-rancher/issues')
-      process.exit(1)
-    }
+    var search = 'linux'
     var platform = new RegExp(process.arch, 'i')
     var searchRE = new RegExp(search, 'i')
     var found = false // we only need one archive for our platform and we'll figure it out
+
     // FIXME do a final version check
-    options.cb = cb
     for(var i in data.assets) {
       var asset = data.assets[i]
       //console.log(i, 'asset', asset.browser_download_url)

--- a/modes/download-binaries.js
+++ b/modes/download-binaries.js
@@ -264,9 +264,27 @@ async function downloadGithubRepo(github_url, options, config, curVerStr, cb) {
       }
     }
 
+    if (os.platform() == 'linux') {
+      if (options.filename === 'lokinet' && options.notPrerelease) {
+        // get version number
+        //console.log('data', data)
+        const dirName = 'lokinet-linux-amd64-' + data.tag_name
+        options.ext = '.tar.xz'
+        const specialLokinetLinuxStaticBinaryUrl = 'https://oxen.rocks/oxen-io/loki-network/' + dirName + options.ext
+        downloadArchive(specialLokinetLinuxStaticBinaryUrl, config, options)
+        return
+      }
+    }
+    /*
+    else {
+       console.log('Non Linux systems must download/build binaries on their own')
+       process.exit(1)
+    }
+    */
+
     var search = 'UNKNOWN'
-    if (os.platform() == 'darwin') search = 'osx'
-    else
+    //if (os.platform() == 'darwin') search = 'osx'
+    //else
     if (os.platform() == 'linux') search = 'linux'
     else {
       console.error('Sorry, platform', os.platform(), 'is not currently supported, please let us know you would like us to support this platform by opening an issue on github: https://github.com/hesiod-project/oxen-rancher/issues')

--- a/modes/status.js
+++ b/modes/status.js
@@ -49,14 +49,27 @@ async function status() {
     // if we have a launcher, then ofc the port SHOULD be in use...
 
   }
+
+  const ransysd = require(__dirname + '/check-systemd')
+  const installed = ransysd.isSystemdEnabled(config)
+  let restartUser
+  if (installed) {
+    restartUser = ransysd.getUser()
+  }
+  console.log('Will launch on restart:', installed ? ('as ' + restartUser) : 'no')
+
   //console.log('status pids', pids)
   //console.log('running', running)
   // if the launcher is running
   if (running.launcher) {
+    const sysdrunning = ransysd.isStartedWithSystemD()
+    console.log('Will restart on rancher crash:', sysdrunning ? 'yes' : 'no')
+    // FIXME: compare running user with restartUser
   } else {
     console.log('Rancher is not running')
     // FIXME: may want to check on child daemons to make sure they're not free floating?
   }
+
   // launcher will always be imperfect
   // show info IF we have it
   // processes may be broken/zombies
@@ -72,6 +85,8 @@ async function status() {
 
   // "not running" but too easy to confuse with "running"
   await lib.getLauncherStatus(config, lokinet, 'offline', function(running, checklist) {
+
+
     //console.log('nodeVer', nodeVer)
     if (nodeVer >= 10) {
       console.table(checklist)

--- a/src/lib/lib.systemd.js
+++ b/src/lib/lib.systemd.js
@@ -45,17 +45,22 @@ function isActive(service) {
   }
 }
 
+// requires root
 function serviceStart(service) {
   const out = libexec.execOut('systemctl start ' + service)
   //console.log('serviceStart', out)
 /*
 Job for loki-node.service failed because the control process exited with error code.
 See "systemctl status loki-node.service" and "journalctl -xe" for details.
+
+Failed to start lokid.service: The name org.freedesktop.PolicyKit1 was not provided by any .service files
+See system logs and 'systemctl status lokid.service' for details.
 otherwise quiet
 */
-  return out
+  return !out.match(/failed/i)
 }
 
+// requires root
 function serviceStop(service) {
   const out = libexec.execOut('systemctl stop ' + service)
   // silent whether it's stopped or not
@@ -63,6 +68,7 @@ function serviceStop(service) {
   return out
 }
 
+// requires root
 function serviceEnable(service) {
   const out = libexec.execOut('systemctl enable ' + service)
   // Created symlink /etc/systemd/system/multi-user.target.wants/loki-node.service → /lib/systemd/system/loki-node.service.
@@ -70,15 +76,16 @@ function serviceEnable(service) {
   return out.match(/Created symlink /)
 }
 
+// requires root
 function serviceDisable(service) {
   const out = libexec.execOut('systemctl disable ' + service)
   // Removed /etc/systemd/system/multi-user.target.wants/loki-node.service.
   //console.log('serviceDisable', out)
   return out.match(/Removed /)
 }
-
+// requires root
 function refreshServices() {
-  const out = libexec.execOut('systemctl daemon reload')
+  const out = libexec.execOut('systemctl daemon-reload')
   // no out on sucess
   return out
 }

--- a/src/lib/lib.systemd.js
+++ b/src/lib/lib.systemd.js
@@ -66,14 +66,20 @@ function serviceStop(service) {
 function serviceEnable(service) {
   const out = libexec.execOut('systemctl enable ' + service)
   // Created symlink /etc/systemd/system/multi-user.target.wants/loki-node.service → /lib/systemd/system/loki-node.service.
-  console.log('serviceEnable', out)
-  return out
+  //console.log('serviceEnable', out)
+  return out.match(/Created symlink /)
 }
 
 function serviceDisable(service) {
   const out = libexec.execOut('systemctl disable ' + service)
   // Removed /etc/systemd/system/multi-user.target.wants/loki-node.service.
-  console.log('serviceDisable', out)
+  //console.log('serviceDisable', out)
+  return out.match(/Removed /)
+}
+
+function refreshServices() {
+  const out = libexec.execOut('systemctl daemon reload')
+  // no out on sucess
   return out
 }
 
@@ -153,5 +159,6 @@ module.exports = {
   serviceStart,
   serviceEnable,
   serviceDisable,
+  refreshServices,
   notify: notifySystemd
 }

--- a/start.js
+++ b/start.js
@@ -185,8 +185,10 @@ module.exports = function(args, config, entryPoint, debug) {
     //transport-privkey=/Users/admin/.lokinet/transport.private
     //encryption-privkey=/Users/admin/.lokinet/encryption.private
     var version = lib.getNetworkVersion(config)
-    // 0.8.x doesn't need to prefix
-    const needToPrepend = (!version || !version.match('lokinet-0.8.'))
+    // 0.8.x+ doesn't need to prefix
+    const needToPrepend = (!version || !(
+      version.match('lokinet-0.8.') || version.match('lokinet-0.9.')
+    ))
     if (needToPrepend) {
       config.network.transport_privkey = config.network.data_dir + '/transport.private'
       config.network.encryption_privkey = config.network.data_dir + '/encryption.private'

--- a/systemd/lokid.service
+++ b/systemd/lokid.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Oxen rancher service node
+After=network-online.target
+
+[Service]
+LimitNOFILE=16384
+Type=simple
+User=snode
+ExecStart=/root/loki-launcher-dev/index.js systemd-start
+Restart=always
+RestartSec=30s
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Changelog:
- lokinet data_dir fix
- new systemd helper commands:
  - install USER - installs service file for you
  - enable - enables service file for you
  - check - get systemd status
  - upgrade - make sure service file is up to date
  - disable - disable service file for you
  - uninstall - uninstalls service file for you
- Use new lokinet static linux binary release URL
- additional loki-launcher => OR and text clean up
- make USER optional on upgrade command
- include blockchain status (syncing, loading services) in status
- consider a syncing blockchain a startup success for now
- fix bug with not passing last command line parameter to oxend